### PR TITLE
Fix true path calculation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -125,7 +125,7 @@ function addHeaderLicense (fileInfo, owner) {
       }
 
       // Remove extra "/" at beginning of path.
-      var truePath = fileInfo.path.substr(1);
+      var truePath = fileInfo.path.indexOf('//') == 0 ? fileInfo.path.substr(1) :  fileInfo.path;
 
       // Open file, add license, save file.
       var data = fs.readFileSync(truePath).toString();


### PR DESCRIPTION
This snippet not only removes the extra `/` at the beginning, but removes the right one too which ends in file not found `home/mhmxs/...`. This change removes only the extra slash. Maybe Replacing all `//` from the file path makes more sense.